### PR TITLE
[fix issue 4] add multistream support

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1,183 +1,192 @@
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
     <modelVersion>4.0.0</modelVersion>
 
     <groupId>me.lemire.lucene</groupId>
     <artifactId>IndexWikipedia</artifactId>
     <version>0.0.1-SNAPSHOT</version>
-    
-    <packaging>bundle</packaging> 
+
+    <packaging>bundle</packaging>
     <properties>
         <maven.compiler.source>1.6</maven.compiler.source>
         <maven.compiler.target>1.6</maven.compiler.target>
         <encoding>UTF-8</encoding>
     </properties>
-	<licenses>
-	  <license>
-	    <name>Apache 2</name>
-	    <url>http://www.apache.org/licenses/LICENSE-2.0.txt</url>
-	    <distribution>repo</distribution>
-	    <comments>A business-friendly OSS license</comments>
-	  </license>
-	</licenses>
-      <developers>
-    <developer>
-      <id>lemire</id>
-      <name>Daniel Lemire</name>
-      <email>lemire@gmail.com</email>
-      <url>http://lemire.me/en/</url>
-      <organization>LICEF Research Center</organization>
-      <organizationUrl>http://licef.ca</organizationUrl>
-      <roles>
-        <role>architect</role>
-        <role>developer</role>
-        <role>maintainer</role>
-      </roles>
-      <timezone>-5</timezone>
-      <properties>
-        <picUrl>http://lemire.me/fr/images/JPG/profile2011B_152.jpg</picUrl>
-      </properties>
-    </developer>
-  </developers>
-   <dependencies>
+    <licenses>
+        <license>
+            <name>Apache 2</name>
+            <url>http://www.apache.org/licenses/LICENSE-2.0.txt</url>
+            <distribution>repo</distribution>
+            <comments>A business-friendly OSS license</comments>
+        </license>
+    </licenses>
+    <developers>
+        <developer>
+            <id>lemire</id>
+            <name>Daniel Lemire</name>
+            <email>lemire@gmail.com</email>
+            <url>http://lemire.me/en/</url>
+            <organization>LICEF Research Center</organization>
+            <organizationUrl>http://licef.ca</organizationUrl>
+            <roles>
+                <role>architect</role>
+                <role>developer</role>
+                <role>maintainer</role>
+            </roles>
+            <timezone>-5</timezone>
+            <properties>
+                <picUrl>http://lemire.me/fr/images/JPG/profile2011B_152.jpg</picUrl>
+            </properties>
+        </developer>
+    </developers>
+    <dependencies>
         <dependency>
             <groupId>junit</groupId>
             <artifactId>junit</artifactId>
             <version>4.10</version>
             <scope>test</scope>
         </dependency>
-<dependency>
-	<groupId>org.apache.lucene</groupId>
-	<artifactId>lucene-benchmark</artifactId>
-	<version>6.2.0</version>
-</dependency>
-
-   </dependencies>
-   <parent>
-    <groupId>org.sonatype.oss</groupId>
-    <artifactId>oss-parent</artifactId>
-    <version>5</version>
-  </parent>
+        <dependency>
+            <groupId>org.apache.lucene</groupId>
+            <artifactId>lucene-benchmark</artifactId>
+            <version>6.2.0</version>
+        </dependency>
+    </dependencies>
+    <parent>
+        <groupId>org.sonatype.oss</groupId>
+        <artifactId>oss-parent</artifactId>
+        <version>5</version>
+    </parent>
     <build>
-    <plugins>
- <plugin>
-<artifactId>maven-assembly-plugin</artifactId>
-<executions>
-  <execution>
-    <phase>package</phase>
-    <goals>
-      <goal>single</goal>
-    </goals>
-  </execution>
-</executions>
-<configuration>
-  <descriptorRefs>
-    <descriptorRef>jar-with-dependencies</descriptorRef>
-  </descriptorRefs>
-</configuration>
-</plugin>
-   <plugin>
-    <groupId>org.apache.maven.plugins</groupId>
-    <artifactId>maven-eclipse-plugin</artifactId>
-    <configuration>
-        <downloadSources>true</downloadSources>
-        <downloadJavadocs>true</downloadJavadocs>
-    </configuration>
-</plugin>
-         <plugin>
-  <groupId>org.codehaus.mojo</groupId>
-  <artifactId>exec-maven-plugin</artifactId>
-  <version>1.1</version>
-  <configuration>
-    <mainClass>me.lemire.lucene.IndexDump</mainClass>
-  </configuration>
-</plugin> 
-	   <plugin>
-			<groupId>org.apache.felix</groupId>
-			<artifactId>maven-bundle-plugin</artifactId>
-			<version>2.3.7</version>
-			<extensions>true</extensions>
-			<configuration>
-				<instructions>
-					<Export-Package>me.lemire.lucene.*</Export-Package>
-					<Import-Package>*</Import-Package>
-				</instructions>
-			</configuration>
-      </plugin>
-      <plugin>
-        <groupId>org.apache.maven.plugins</groupId>
-        <artifactId>maven-gpg-plugin</artifactId>
-        <version>1.4</version>
-        <executions>
-          <execution>
-            <id>sign-artifacts</id>
-            <phase>verify</phase>
-            <goals>
-              <goal>sign</goal>
-            </goals>
-          </execution>
-        </executions>
-      </plugin>
-      
-  <plugin>
-                                <groupId>org.apache.maven.plugins</groupId>
-                                <artifactId>maven-deploy-plugin</artifactId>
-                                <version>2.7</version>
-                                <dependencies>
-                                        <dependency>
-                                                <groupId>com.google.code.maven-svn-wagon</groupId>
-                                                <artifactId>maven-svn-wagon</artifactId>
-                                                <version>1.4</version>
-                                        </dependency>
-                                </dependencies>
-                        </plugin>    		<plugin>
-			<groupId>org.apache.maven.plugins</groupId>
-			<artifactId>maven-javadoc-plugin</artifactId>
-			<version>2.8</version>
+        <plugins>
+            <plugin>
+                <artifactId>maven-assembly-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <phase>package</phase>
+                        <goals>
+                            <goal>single</goal>
+                        </goals>
+                    </execution>
+                </executions>
+                <configuration>
+                    <descriptorRefs>
+                        <descriptorRef>jar-with-dependencies</descriptorRef>
+                    </descriptorRefs>
+                </configuration>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-eclipse-plugin</artifactId>
+                <configuration>
+                    <downloadSources>true</downloadSources>
+                    <downloadJavadocs>true</downloadJavadocs>
+                </configuration>
+            </plugin>
+            <plugin>
+                <groupId>org.codehaus.mojo</groupId>
+                <artifactId>exec-maven-plugin</artifactId>
+                <version>1.1</version>
+                <configuration>
+                    <mainClass>me.lemire.lucene.IndexDump</mainClass>
+                </configuration>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.felix</groupId>
+                <artifactId>maven-bundle-plugin</artifactId>
+                <version>2.3.7</version>
+                <extensions>true</extensions>
+                <configuration>
+                    <instructions>
+                        <Export-Package>me.lemire.lucene.*</Export-Package>
+                        <Import-Package>*</Import-Package>
+                    </instructions>
+                </configuration>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-gpg-plugin</artifactId>
+                <version>1.4</version>
+                <executions>
+                    <execution>
+                        <id>sign-artifacts</id>
+                        <phase>verify</phase>
+                        <goals>
+                            <goal>sign</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
 
-			<executions>
-				<execution>
-					<id>attach-javadocs</id>
-					<goals>
-						<goal>jar</goal>
-					</goals>
-				</execution>
-			</executions>
-		</plugin>
-<plugin>
-            <groupId>org.apache.maven.plugins</groupId>
-            <artifactId>maven-dependency-plugin</artifactId>
-            <executions>
-                <execution>
-                    <id>copy-dependencies</id>
-                    <phase>prepare-package</phase>
-                    <goals>
-                        <goal>copy-dependencies</goal>
-                    </goals>
-                    <configuration>
-                        <outputDirectory>${project.build.directory}/lib</outputDirectory>
-                        <overWriteReleases>false</overWriteReleases>
-                        <overWriteSnapshots>false</overWriteSnapshots>
-                        <overWriteIfNewer>true</overWriteIfNewer>
-                    </configuration>
-                </execution>
-            </executions>
-        </plugin>
-		<plugin>
-			<groupId>org.apache.maven.plugins</groupId>
-			<artifactId>maven-source-plugin</artifactId>
-			<version>2.1.2</version>
-			<executions>
-				<execution>
-					<id>attach-sources</id>
-					<goals>
-						<goal>jar</goal>
-					</goals>
-				</execution>
-			</executions>
-		</plugin>
-    </plugins>
-  </build>
-   <name>IndexWikipedia</name>
-   <url>None</url>
-   <description>Simple utility to index Wikipedia dumps using Lucene. </description>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-deploy-plugin</artifactId>
+                <version>2.7</version>
+                <dependencies>
+                    <dependency>
+                        <groupId>com.google.code.maven-svn-wagon</groupId>
+                        <artifactId>maven-svn-wagon</artifactId>
+                        <version>1.4</version>
+                    </dependency>
+                </dependencies>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-javadoc-plugin</artifactId>
+                <version>2.8</version>
+
+                <executions>
+                    <execution>
+                        <id>attach-javadocs</id>
+                        <goals>
+                            <goal>jar</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-dependency-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <id>copy-dependencies</id>
+                        <phase>prepare-package</phase>
+                        <goals>
+                            <goal>copy-dependencies</goal>
+                        </goals>
+                        <configuration>
+                            <outputDirectory>${project.build.directory}/lib</outputDirectory>
+                            <overWriteReleases>false</overWriteReleases>
+                            <overWriteSnapshots>false</overWriteSnapshots>
+                            <overWriteIfNewer>true</overWriteIfNewer>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-source-plugin</artifactId>
+                <version>2.1.2</version>
+                <executions>
+                    <execution>
+                        <id>attach-sources</id>
+                        <goals>
+                            <goal>jar</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-compiler-plugin</artifactId>
+                <configuration>
+                    <source>7</source>
+                    <target>7</target>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
+    <name>IndexWikipedia</name>
+    <url>None</url>
+    <description>Simple utility to index Wikipedia dumps using Lucene.</description>
 </project>

--- a/src/main/java/me/lemire/lucene/EnwikiContentSource.java
+++ b/src/main/java/me/lemire/lucene/EnwikiContentSource.java
@@ -1,0 +1,332 @@
+package me.lemire.lucene;
+
+import org.apache.lucene.benchmark.byTask.feeds.ContentSource;
+import org.apache.lucene.benchmark.byTask.feeds.DocData;
+import org.apache.lucene.benchmark.byTask.feeds.NoMoreDataException;
+import org.apache.lucene.benchmark.byTask.utils.Config;
+import org.apache.lucene.util.ThreadInterruptedException;
+import org.xml.sax.Attributes;
+import org.xml.sax.InputSource;
+import org.xml.sax.SAXException;
+import org.xml.sax.XMLReader;
+import org.xml.sax.helpers.DefaultHandler;
+import org.xml.sax.helpers.XMLReaderFactory;
+
+import java.io.*;
+import java.nio.charset.Charset;
+import java.nio.charset.CharsetDecoder;
+import java.nio.charset.CodingErrorAction;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.HashMap;
+import java.util.Locale;
+import java.util.Map;
+
+/**
+ * This code is a copy of the original EnwikiContentSource from org.apache.lucene.benchmark.byTask.feeds
+ * but fixed the stream part for `multistream` support
+ * A {@link ContentSource} which reads the English Wikipedia dump. You can read
+ * the .bz2 file directly (it will be decompressed on the fly). Config
+ * properties:
+ * <ul>
+ * <li>keep.image.only.docs=false|true (default <b>true</b>).
+ * <li>docs.file=&lt;path to the file&gt;
+ * </ul>
+ */
+public class EnwikiContentSource extends ContentSource {
+
+    private class Parser extends DefaultHandler implements Runnable {
+        private Thread t;
+        private boolean threadDone;
+        private boolean stopped = false;
+        private String[] tuple;
+        private NoMoreDataException nmde;
+        private StringBuilder contents = new StringBuilder();
+        private String title;
+        private String body;
+        private String time;
+        private String id;
+
+        String[] next() throws NoMoreDataException {
+            if (t == null) {
+                threadDone = false;
+                t = new Thread(this);
+                t.setDaemon(true);
+                t.start();
+            }
+            String[] result;
+            synchronized (this) {
+                while (tuple == null && nmde == null && !threadDone && !stopped) {
+                    try {
+                        wait();
+                    } catch (InterruptedException ie) {
+                        throw new ThreadInterruptedException(ie);
+                    }
+                }
+                if (tuple != null) {
+                    result = tuple;
+                    tuple = null;
+                    notify();
+                    return result;
+                }
+                if (nmde != null) {
+                    // Set to null so we will re-start thread in case
+                    // we are re-used:
+                    t = null;
+                    throw nmde;
+                }
+                // The thread has exited yet did not hit end of
+                // data, so this means it hit an exception.  We
+                // throw NoMorDataException here to force
+                // benchmark to stop the current alg:
+                throw new NoMoreDataException();
+            }
+        }
+
+        String time(String original) {
+            StringBuilder buffer = new StringBuilder();
+
+            buffer.append(original.substring(8, 10));
+            buffer.append('-');
+            buffer.append(months[Integer.valueOf(original.substring(5, 7)).intValue() - 1]);
+            buffer.append('-');
+            buffer.append(original.substring(0, 4));
+            buffer.append(' ');
+            buffer.append(original.substring(11, 19));
+            buffer.append(".000");
+
+            return buffer.toString();
+        }
+
+        @Override
+        public void characters(char[] ch, int start, int length) {
+            contents.append(ch, start, length);
+        }
+
+        @Override
+        public void endElement(String namespace, String simple, String qualified)
+                throws SAXException {
+            int elemType = getElementType(qualified);
+            switch (elemType) {
+                case PAGE:
+                    // the body must be null and we either are keeping image docs or the
+                    // title does not start with Image:
+                    if (body != null && (keepImages || !title.startsWith("Image:"))) {
+                        String[] tmpTuple = new String[LENGTH];
+                        tmpTuple[TITLE] = title.replace('\t', ' ');
+                        tmpTuple[DATE] = time.replace('\t', ' ');
+                        tmpTuple[BODY] = body.replaceAll("[\t\n]", " ");
+                        tmpTuple[ID] = id;
+                        synchronized (this) {
+                            while (tuple != null && !stopped) {
+                                try {
+                                    wait();
+                                } catch (InterruptedException ie) {
+                                    throw new ThreadInterruptedException(ie);
+                                }
+                            }
+                            tuple = tmpTuple;
+                            notify();
+                        }
+                    }
+                    break;
+                case BODY:
+                    body = contents.toString();
+                    //workaround that startswith doesn't have an ignore case option, get at least 20 chars.
+                    String startsWith = body.substring(0, Math.min(10, contents.length())).toLowerCase(Locale.ROOT);
+                    if (startsWith.startsWith("#redirect")) {
+                        body = null;
+                    }
+                    break;
+                case DATE:
+                    time = time(contents.toString());
+                    break;
+                case TITLE:
+                    title = contents.toString();
+                    break;
+                case ID:
+                    //the doc id is the first one in the page.  All other ids after that one can be ignored according to the schema
+                    if (id == null) {
+                        id = contents.toString();
+                    }
+                    break;
+                default:
+                    // this element should be discarded.
+            }
+        }
+
+        public Reader getDecodingReader(InputStream stream, Charset charSet) {
+            final CharsetDecoder charSetDecoder = charSet.newDecoder()
+                    .onMalformedInput(CodingErrorAction.REPORT)
+                    .onUnmappableCharacter(CodingErrorAction.REPORT);
+            try {
+                return new BufferedReader(new InputStreamReader(new MultiStreamBZip2InputStream(stream), charSetDecoder));
+            } catch (IOException e) {
+                e.printStackTrace();
+            }
+            return null;
+        }
+
+        @Override
+        public void run() {
+
+            try {
+                XMLReader reader = XMLReaderFactory.createXMLReader();
+                reader.setContentHandler(this);
+                reader.setErrorHandler(this);
+                while (!stopped) {
+                    final InputStream localFileIS = is;
+                    if (localFileIS != null) { // null means fileIS was closed on us
+                        try {
+                            // To work around a bug in XERCES (XERCESJ-1257), we assume the XML is always UTF8, so we simply provide reader.
+                            reader.parse(new InputSource(getDecodingReader(localFileIS, StandardCharsets.UTF_8)));
+                        } catch (IOException ioe) {
+                            synchronized (EnwikiContentSource.this) {
+                                if (localFileIS != is) {
+                                    // fileIS was closed on us, so, just fall through
+                                } else
+                                    // Exception is real
+                                    throw ioe;
+                            }
+                        }
+                    }
+                    synchronized (this) {
+                        if (stopped || !forever) {
+                            nmde = new NoMoreDataException();
+                            notify();
+                            return;
+                        } else if (localFileIS == is) {
+                            // If file is not already re-opened then re-open it now
+                            is = openInputStream();
+                        }
+                    }
+                }
+            } catch (SAXException | IOException sae) {
+                throw new RuntimeException(sae);
+            } finally {
+                synchronized (this) {
+                    threadDone = true;
+                    notify();
+                }
+            }
+        }
+
+        @Override
+        public void startElement(String namespace, String simple, String qualified,
+                                 Attributes attributes) {
+            int elemType = getElementType(qualified);
+            switch (elemType) {
+                case PAGE:
+                    title = null;
+                    body = null;
+                    time = null;
+                    id = null;
+                    break;
+                // intentional fall-through.
+                case BODY:
+                case DATE:
+                case TITLE:
+                case ID:
+                    contents.setLength(0);
+                    break;
+                default:
+                    // this element should be discarded.
+            }
+        }
+
+        private void stop() {
+            synchronized (this) {
+                stopped = true;
+                if (tuple != null) {
+                    tuple = null;
+                    notify();
+                }
+            }
+        }
+
+    }
+
+    private static final Map<String, Integer> ELEMENTS = new HashMap<>();
+    private static final int TITLE = 0;
+    private static final int DATE = TITLE + 1;
+    private static final int BODY = DATE + 1;
+    private static final int ID = BODY + 1;
+    private static final int LENGTH = ID + 1;
+    // LENGTH is used as the size of the tuple, so whatever constants we need that
+    // should not be part of the tuple, we should define them after LENGTH.
+    private static final int PAGE = LENGTH + 1;
+
+    private static final String[] months = {"JAN", "FEB", "MAR", "APR",
+            "MAY", "JUN", "JUL", "AUG",
+            "SEP", "OCT", "NOV", "DEC"};
+
+    static {
+        ELEMENTS.put("page", Integer.valueOf(PAGE));
+        ELEMENTS.put("text", Integer.valueOf(BODY));
+        ELEMENTS.put("timestamp", Integer.valueOf(DATE));
+        ELEMENTS.put("title", Integer.valueOf(TITLE));
+        ELEMENTS.put("id", Integer.valueOf(ID));
+    }
+
+    /**
+     * Returns the type of the element if defined, otherwise returns -1. This
+     * method is useful in startElement and endElement, by not needing to compare
+     * the element qualified name over and over.
+     */
+    private final static int getElementType(String elem) {
+        Integer val = ELEMENTS.get(elem);
+        return val == null ? -1 : val.intValue();
+    }
+
+    private Path file;
+    private boolean keepImages = true;
+    private InputStream is;
+    private Parser parser = new Parser();
+
+    @Override
+    public void close() throws IOException {
+        synchronized (EnwikiContentSource.this) {
+            parser.stop();
+            if (is != null) {
+                is.close();
+                is = null;
+            }
+        }
+    }
+
+    @Override
+    public synchronized DocData getNextDocData(DocData docData) throws NoMoreDataException, IOException {
+        String[] tuple = parser.next();
+        docData.clear();
+        docData.setName(tuple[ID]);
+        docData.setBody(tuple[BODY]);
+        docData.setDate(tuple[DATE]);
+        docData.setTitle(tuple[TITLE]);
+        return docData;
+    }
+
+    @Override
+    public void resetInputs() throws IOException {
+        super.resetInputs();
+        is = openInputStream();
+    }
+
+    /**
+     * Open the input stream.
+     */
+    protected InputStream openInputStream() throws IOException {
+        return new FileInputStream(String.valueOf(file));
+    }
+
+    @Override
+    public void setConfig(Config config) {
+        super.setConfig(config);
+        keepImages = config.get("keep.image.only.docs", true);
+        String fileName = config.get("docs.file", null);
+        if (fileName != null) {
+            file = Paths.get(fileName).toAbsolutePath();
+        }
+    }
+}
+

--- a/src/main/java/me/lemire/lucene/IndexDump.java
+++ b/src/main/java/me/lemire/lucene/IndexDump.java
@@ -4,7 +4,6 @@ import java.io.File;
 import java.util.Properties;
 import org.apache.lucene.analysis.standard.StandardAnalyzer;
 import org.apache.lucene.benchmark.byTask.feeds.DocMaker;
-import org.apache.lucene.benchmark.byTask.feeds.EnwikiContentSource;
 import org.apache.lucene.benchmark.byTask.utils.Config;
 import org.apache.lucene.document.*;
 import org.apache.lucene.index.*;

--- a/src/main/java/me/lemire/lucene/MultiStreamBZip2InputStream.java
+++ b/src/main/java/me/lemire/lucene/MultiStreamBZip2InputStream.java
@@ -1,0 +1,68 @@
+package me.lemire.lucene;
+
+import java.io.IOException;
+import java.io.InputStream;
+
+import org.apache.commons.compress.compressors.CompressorInputStream;
+import org.apache.commons.compress.compressors.bzip2.BZip2CompressorInputStream;
+
+/**
+ * Original code posted in [https://chaosinmotion.blog/2011/07/29/and-another-curiosity-multi-stream-bzip2-files/]
+ * Handle multistream BZip2 files.
+ */
+public class MultiStreamBZip2InputStream extends CompressorInputStream {
+    private InputStream fInputStream;
+    private BZip2CompressorInputStream fBZip2;
+
+    public MultiStreamBZip2InputStream(InputStream in) throws IOException {
+        fInputStream = in;
+        fBZip2 = new BZip2CompressorInputStream(in);
+    }
+
+    @Override
+    public int read() throws IOException {
+        int ch = fBZip2.read();
+        if (ch == -1) {
+            /*
+             * If this is a multistream file, there will be more data that
+             * follows that is a valid compressor input stream. Restart the
+             * decompressor engine on the new segment of the data.
+             */
+            if (fInputStream.available() > 0) {
+                // Make use of the fact that if we hit EOF, the data for
+                // the old compressor was deleted already, so we don't need
+                // to close.
+                fBZip2 = new BZip2CompressorInputStream(fInputStream);
+                ch = fBZip2.read();
+            }
+        }
+        return ch;
+    }
+
+    /**
+     * Read the data from read(). This makes sure we funnel through read so
+     * we can do our multistream magic.
+     */
+    public int read(byte[] dest, int off, int len) throws IOException {
+        if ((off < 0) || (len < 0) || (off + len > dest.length)) {
+            throw new IndexOutOfBoundsException();
+        }
+
+        int i = 1;
+        int c = read();
+        if (c == -1) return -1;
+        dest[off++] = (byte) c;
+        while (i < len) {
+            c = read();
+            if (c == -1) break;
+            dest[off++] = (byte) c;
+            ++i;
+        }
+        return i;
+    }
+
+    public void close() throws IOException {
+        fBZip2.close();
+        fInputStream.close();
+    }
+}


### PR DESCRIPTION
Fix [Issue 4](https://github.com/lemire/IndexWikipedia/issues/4)

Hi, I tried to resolve the problem with the code I searched online, I added reference in the comment part.

I tested the code,  it can handle both `multistream` and common bz2 files, here are the results:
```
➜  IndexWikipedia git:(master) ✗ mvn exec:java -Dexec.args="/home/vimos/Data/Dataset/Wikipedia/enwiki-latest-pages-articles-multistream.xml.bz2 /home/vimos/Data/Dataset/Wikipedia/index"
[INFO] Scanning for projects...
[WARNING] 
[WARNING] Some problems were encountered while building the effective model for me.lemire.lucene:IndexWikipedia:bundle:0.0.1-SNAPSHOT
[WARNING] 'build.plugins.plugin.version' for org.apache.maven.plugins:maven-compiler-plugin is missing. @ line 179, column 21
[WARNING] 'build.plugins.plugin.version' for org.apache.maven.plugins:maven-eclipse-plugin is missing. @ line 78, column 21
[WARNING] 
[WARNING] It is highly recommended to fix these problems because they threaten the stability of your build.
[WARNING] 
[WARNING] For this reason, future Maven versions might no longer support building such malformed projects.
[WARNING] 
[INFO] 
[INFO] ------------------------------------------------------------------------
[INFO] Building IndexWikipedia 0.0.1-SNAPSHOT
[INFO] ------------------------------------------------------------------------
[INFO] 
[INFO] >>> exec-maven-plugin:1.1:java (default-cli) > validate @ IndexWikipedia >>>
[INFO] 
[INFO] --- maven-enforcer-plugin:1.0-beta-1:enforce (enforce-maven) @ IndexWikipedia ---
[INFO] 
[INFO] <<< exec-maven-plugin:1.1:java (default-cli) < validate @ IndexWikipedia <<<
[INFO] 
[INFO] 
[INFO] --- exec-maven-plugin:1.1:java (default-cli) @ IndexWikipedia ---
------------> config properties:
content.source.forever = false
docs.file = /home/vimos/Data/Dataset/Wikipedia/enwiki-latest-pages-articles-multistream.xml.bz2
keep.image.only.docs = false
-------------------------------
Starting Indexing of Wikipedia dump /home/vimos/Data/Dataset/Wikipedia/enwiki-latest-pages-articles-multistream.xml.bz2
Indexing 100 documents took 1371 ms
Index should be located at /home/vimos/Data/Dataset/Wikipedia/index
We are going to test the index by querying the word 'other' and getting the top 3 documents:
Hit: 
docid : 20
name : 569
title : Anthropology
body : {{About|anthropology in the 20th and 21s...
Hit: 
docid : 61
name : 670
title : Alphabet
body : {{pp-semi-indef}} {{about|sets of letter...
Hit: 
docid : 98
name : 752
title : Art
body : {{about|the general concept of art|the g...
[INFO] ------------------------------------------------------------------------
[INFO] BUILD SUCCESS
[INFO] ------------------------------------------------------------------------
[INFO] Total time: 2.388 s
[INFO] Finished at: 2018-05-16T19:06:31+08:00
[INFO] Final Memory: 24M/406M
[INFO] ------------------------------------------------------------------------
```
```
➜  IndexWikipedia git:(master) ✗ mvn exec:java -Dexec.args="/home/vimos/Data/Dataset/Wikipedia/enwiki-latest-pages-articles10.xml-p2336425p3046511.bz2 /home/vimos/Data/Dataset/Wikipedia/index"
[INFO] Scanning for projects...
[WARNING] 
[WARNING] Some problems were encountered while building the effective model for me.lemire.lucene:IndexWikipedia:bundle:0.0.1-SNAPSHOT
[WARNING] 'build.plugins.plugin.version' for org.apache.maven.plugins:maven-compiler-plugin is missing. @ line 179, column 21
[WARNING] 'build.plugins.plugin.version' for org.apache.maven.plugins:maven-eclipse-plugin is missing. @ line 78, column 21
[WARNING] 
[WARNING] It is highly recommended to fix these problems because they threaten the stability of your build.
[WARNING] 
[WARNING] For this reason, future Maven versions might no longer support building such malformed projects.
[WARNING] 
[INFO] 
[INFO] ------------------------------------------------------------------------
[INFO] Building IndexWikipedia 0.0.1-SNAPSHOT
[INFO] ------------------------------------------------------------------------
[INFO] 
[INFO] >>> exec-maven-plugin:1.1:java (default-cli) > validate @ IndexWikipedia >>>
[INFO] 
[INFO] --- maven-enforcer-plugin:1.0-beta-1:enforce (enforce-maven) @ IndexWikipedia ---
[INFO] 
[INFO] <<< exec-maven-plugin:1.1:java (default-cli) < validate @ IndexWikipedia <<<
[INFO] 
[INFO] 
[INFO] --- exec-maven-plugin:1.1:java (default-cli) @ IndexWikipedia ---
------------> config properties:
content.source.forever = false
docs.file = /home/vimos/Data/Dataset/Wikipedia/enwiki-latest-pages-articles10.xml-p2336425p3046511.bz2
keep.image.only.docs = false
-------------------------------
Starting Indexing of Wikipedia dump /home/vimos/Data/Dataset/Wikipedia/enwiki-latest-pages-articles10.xml-p2336425p3046511.bz2
Indexing 100 documents took 465 ms
Index should be located at /home/vimos/Data/Dataset/Wikipedia/index
We are going to test the index by querying the word 'other' and getting the top 3 documents:
Hit: 
docid : 36
name : 2336561
title : Spanish Mastiff
body : <!-- Begin Infobox Dogbreed.  The text o...
Hit: 
docid : 87
name : 2336710
title : Wikipedia:Featured article candidates/So...
body : ===[[Sociocultural evolution]]=== Self n...
Hit: 
docid : 51
name : 2336592
title : Flight envelope
body : {{Refimprove|date=June 2009}} [[Image:Pe...
[INFO] ------------------------------------------------------------------------
[INFO] BUILD SUCCESS
[INFO] ------------------------------------------------------------------------
[INFO] Total time: 1.293 s
[INFO] Finished at: 2018-05-16T19:06:24+08:00
[INFO] Final Memory: 25M/370M
[INFO] ------------------------------------------------------------------------
```

I don't code Java a lot, feel free to decline the pull request if you don't like the code! 
